### PR TITLE
Change form URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
         <div class="container">
             <div class="section" style="text-align: justify;">
                 <ul class="browser-default">
-                    <li>Cierre de envío de propuestas para charlas y tutoriales: 06 de septiembre</li>
+                    <li>Cierre de envío de propuestas para charlas y tutoriales: 6 de septiembre</li>
                     <li>Cierre de envío de propuestas para posters y lightning talks: 20 de septiembre</li>
                     <li>Notificación aceptación de propuestas: 27 de septiembre</li>
                     <li>Notificación otorgamiento de becas: 27 de septiembre</li>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                 <p>El Taller Argentino de Computación Científica (TAC²) tiene como objetivo reunir a estudiantes, docentes e investigadores que realizan contribuciones originales en el ámbito científico, en cualquiera de sus múltiples sub-disciplinas, utilizando como herramienta principal la programación científica.</p>
             </div>
             <div class="row center">
-                <a href="https://docs.google.com/forms/d/e/1FAIpQLSf9xfOTGNfwR0y36JF4GoILsDeZDEkofWmq8Hf0yFO1awbVng/viewform?usp=sf_link" id="download-button" class="btn-large waves-effect waves-light blue darken-4">Inscripción y envío de propuestas</a>
+                <a href="https://docs.google.com/forms/d/e/1FAIpQLSePFrapGsdMkvuZNFDwzmKprbkteZJkEbHayh8QLJgeY8RuvA/viewform?usp=sf_link" id="download-button" class="btn-large waves-effect waves-light blue darken-4">Inscripción y envío de propuestas</a>
             </div>
             <br><br>
             </div>
@@ -74,11 +74,10 @@
         <div class="container">
             <div class="section" style="text-align: justify;">
                 <ul class="browser-default">
-                    <li>Cierre de envío de propuestas. Charlas y tutoriales: 06-09</li>
-                    <li>Cierre de envío de propuestas. Posters: 06-09</li>
-                    <li>Notificación aceptación de charlas y tutoriales: 20-09</li>
-                    <li>Notificación aceptación de Posters: 20-09</li>
-                    <li>Notificación otorgamiento de Becas: 20-09</li>
+                    <li>Cierre de envío de propuestas para charlas y tutoriales: 06 de septiembre</li>
+                    <li>Cierre de envío de propuestas para posters y lightning talks: 20 de septiembre</li>
+                    <li>Notificación aceptación de propuestas: 27 de septiembre</li>
+                    <li>Notificación otorgamiento de becas: 27 de septiembre</li>
                 </ul>
                 </div>
         </div>


### PR DESCRIPTION
Cambié el formulario para impedir que sigan mandando charlas y tutoriales.
Además extendí el plazo para posters y lightning talks, según lo que hablamos en Slack.
Actualicé las fechas en la página.